### PR TITLE
Fix README for GH

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -24,16 +24,16 @@ This package was developed for fun and to conveniently transport frequently used
 
 ### Available operators
 
-|  Operator  | Description                                                                                                                                           |
-|:----------:|:------------------------------------------------------------------------------------------------------------------------------------------------------|
-|  **`->`**  | Rightwards form of the [common **assignment** operator](https://rdrr.io/r/base/assignOps.html)                                                        |
-| **`%in%`** | Syntactic-sugar version of [**`match`**](https://rdrr.io/r/base/match.html)                                                                           |
-| **`%<>%`** | [**Assignment pipe** operator](https://magrittr.tidyverse.org/reference/compound.html) from the [magrittr](https://magrittr.tidyverse.org/) package   |
-| **`%$%`**  | [**Exposition pipe** operator](https://magrittr.tidyverse.org/reference/exposition.html) from the [magrittr](https://magrittr.tidyverse.org/) package |
-| **`%!>%`** | [**Eager pipe** operator](https://magrittr.tidyverse.org/reference/pipe-eager.html) from the [magrittr](https://magrittr.tidyverse.org/) package      |
-| **`%T>%`** | [**Tee pipe** operator](https://magrittr.tidyverse.org/reference/tee.html) from the [magrittr](https://magrittr.tidyverse.org/) package               |
-| **`%||%`** | [**NULL default** operator](https://rlang.r-lib.org/reference/op-null-default.html) from the [rlang](https://rlang.r-lib.org/) package                |
-| **`%|%`**  | [**NA default** operator](https://rlang.r-lib.org/reference/op-na-default.html) from the [rlang](https://rlang.r-lib.org/) package                    |
+|   Operator   | Description                                                                                                                                           |
+|:------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   **`->`**   | Rightwards form of the [common **assignment** operator](https://rdrr.io/r/base/assignOps.html)                                                        |
+|  **`%in%`**  | Syntactic-sugar version of [**`match`**](https://rdrr.io/r/base/match.html)                                                                           |
+|  **`%<>%`**  | [**Assignment pipe** operator](https://magrittr.tidyverse.org/reference/compound.html) from the [magrittr](https://magrittr.tidyverse.org/) package   |
+|  **`%$%`**   | [**Exposition pipe** operator](https://magrittr.tidyverse.org/reference/exposition.html) from the [magrittr](https://magrittr.tidyverse.org/) package |
+|  **`%!>%`**  | [**Eager pipe** operator](https://magrittr.tidyverse.org/reference/pipe-eager.html) from the [magrittr](https://magrittr.tidyverse.org/) package      |
+|  **`%T>%`**  | [**Tee pipe** operator](https://magrittr.tidyverse.org/reference/tee.html) from the [magrittr](https://magrittr.tidyverse.org/) package               |
+| **`%\|\|%`** | [**NULL default** operator](https://rlang.r-lib.org/reference/op-null-default.html) from the [rlang](https://rlang.r-lib.org/) package                |
+|  **`%\|%`**  | [**NA default** operator](https://rlang.r-lib.org/reference/op-na-default.html) from the [rlang](https://rlang.r-lib.org/) package                    |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ frequently used functions across environments.
 
 ### Available operators
 
-|  Operator  | Description                                                                                                                                           |
-|:----------:|:------------------------------------------------------------------------------------------------------------------------------------------------------|
-|  **`->`**  | Rightwards form of the [common **assignment** operator](https://rdrr.io/r/base/assignOps.html)                                                        |
-| **`%in%`** | Syntactic-sugar version of [**`match`**](https://rdrr.io/r/base/match.html)                                                                           |
-| **`%<>%`** | [**Assignment pipe** operator](https://magrittr.tidyverse.org/reference/compound.html) from the [magrittr](https://magrittr.tidyverse.org/) package   |
-| **`%$%`**  | [**Exposition pipe** operator](https://magrittr.tidyverse.org/reference/exposition.html) from the [magrittr](https://magrittr.tidyverse.org/) package |
-| **`%!>%`** | [**Eager pipe** operator](https://magrittr.tidyverse.org/reference/pipe-eager.html) from the [magrittr](https://magrittr.tidyverse.org/) package      |
-| **`%T>%`** | [**Tee pipe** operator](https://magrittr.tidyverse.org/reference/tee.html) from the [magrittr](https://magrittr.tidyverse.org/) package               |
-| **`%||%`** | [**NULL default** operator](https://rlang.r-lib.org/reference/op-null-default.html) from the [rlang](https://rlang.r-lib.org/) package                |
-| **`%|%`**  | [**NA default** operator](https://rlang.r-lib.org/reference/op-na-default.html) from the [rlang](https://rlang.r-lib.org/) package                    |
+|   Operator   | Description                                                                                                                                           |
+|:------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   **`->`**   | Rightwards form of the [common **assignment** operator](https://rdrr.io/r/base/assignOps.html)                                                        |
+|  **`%in%`**  | Syntactic-sugar version of [**`match`**](https://rdrr.io/r/base/match.html)                                                                           |
+|  **`%<>%`**  | [**Assignment pipe** operator](https://magrittr.tidyverse.org/reference/compound.html) from the [magrittr](https://magrittr.tidyverse.org/) package   |
+|  **`%$%`**   | [**Exposition pipe** operator](https://magrittr.tidyverse.org/reference/exposition.html) from the [magrittr](https://magrittr.tidyverse.org/) package |
+|  **`%!>%`**  | [**Eager pipe** operator](https://magrittr.tidyverse.org/reference/pipe-eager.html) from the [magrittr](https://magrittr.tidyverse.org/) package      |
+|  **`%T>%`**  | [**Tee pipe** operator](https://magrittr.tidyverse.org/reference/tee.html) from the [magrittr](https://magrittr.tidyverse.org/) package               |
+| **`%\|\|%`** | [**NULL default** operator](https://rlang.r-lib.org/reference/op-null-default.html) from the [rlang](https://rlang.r-lib.org/) package                |
+|  **`%\|%`**  | [**NA default** operator](https://rlang.r-lib.org/reference/op-na-default.html) from the [rlang](https://rlang.r-lib.org/) package                    |
 
 ## Installation
 


### PR DESCRIPTION
Sorry, GitHub needs the `|` to be escaped even if verbatim.